### PR TITLE
Added 'off' method of Sister to player API

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ player.on('stateChange', (event) => {
     // event.data
 });
  ```
+ 
+`player.off` removes a previously added event listener, e.g.
+
+```js
+var listener = player.on(/* ... */);
+player.off(listener)
+```
 
 ## Examples
 

--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,7 @@ export default (elementId, options = {}) => {
 
     playerAPI = YouTubePlayer.promisifyPlayer(playerAPIReady);
     playerAPI.on = emitter.on;
+    playerAPI.off = emitter.off;
 
     return playerAPI;
 };


### PR DESCRIPTION
You are able to add event listeners to the event emitter, but there is no option to clean up event listeners after you are done listening. Simple fix to expose the 'off' method of Sister to the player api.
