### PR TITLE
Fix creating multiple YouTube players.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,8 @@ import YouTubePlayer from './YouTubePlayer';
  * @param {Object} events
  */
 
+let youtubeIframeAPI;
+
 /**
  * A factory function used to produce an instance of YT.Player and queue function calls and proxy events of the resulting object.
  *
@@ -24,10 +26,11 @@ import YouTubePlayer from './YouTubePlayer';
 export default (elementId, options = {}) => {
     let emitter,
         playerAPI,
-        playerAPIReady,
-        youtubeIframeAPI;
+        playerAPIReady;
 
-    youtubeIframeAPI = loadYouTubeIframeAPI();
+    if (!youtubeIframeAPI) {
+        youtubeIframeAPI = loadYouTubeIframeAPI();
+    }
 
     playerAPI = {};
     emitter = Sister();


### PR DESCRIPTION
After 1a01ff9cc, the youtubePlayer factory function tries to load the
YouTube API every time it's called. However the YouTube API
only calls its load event (the global callback) once, when it's first
loaded. As a result, the youtubeIframeAPI promise never
resolves after the first call.

This patch only loads the iframe API on the first call, and reuses
the promise on subsequent calls, similar to what it did before
1a01ff9cc :smile: