### PR TITLE
Replace full lodash dependency for required modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
   "dependencies": {
     "bluebird": "^3.3.0",
     "load-script": "^1.0.0",
-    "lodash": "^4.3.0",
+    "lodash.foreach": "^4.3.0",
+    "lodash.isstring": "^4.0.1",
+    "lodash.upperfirst": "^4.2.0",
     "sister": "^3.0.0"
   }
 }


### PR DESCRIPTION
This replaces the full lodash dependency for only the required lodash modules. 

Essentially, we were concerend with the size of the module and wanted to load only the required lodash modules. Please let me know if you have any questions. 