### PR TITLE
Replaces Bluebird wth native promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "pragmatist": "^3.0.3"
   },
   "dependencies": {
-    "bluebird": "^3.3.0",
     "load-script": "^1.0.0",
     "lodash": "^4.3.0",
     "sister": "^3.0.0"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import Sister from 'sister';
-import Bluebird from 'bluebird';
 import loadYouTubeIframeAPI from './loadYouTubeIframeAPI';
 import YouTubePlayer from './YouTubePlayer';
 
@@ -45,7 +44,7 @@ export default (elementId, options = {}) => {
 
     options.events = YouTubePlayer.proxyEvents(emitter);
 
-    playerAPIReady = new Bluebird((resolve) => {
+    playerAPIReady = new Promise((resolve) => {
         youtubeIframeAPI
             .then((YT) => {
                 return new YT.Player(elementId, options);

--- a/src/loadYouTubeIframeAPI.js
+++ b/src/loadYouTubeIframeAPI.js
@@ -1,4 +1,3 @@
-import Bluebird from 'bluebird';
 import load from 'load-script';
 
 export default () => {
@@ -11,7 +10,7 @@ export default () => {
      * @param {Function} resolve
      * @member {Object} iframeAPIReady
      */
-    iframeAPIReady = new Bluebird((resolve) => {
+    iframeAPIReady = new Promise((resolve) => {
         let previous;
 
         previous = window.onYouTubeIframeAPIReady;


### PR DESCRIPTION
In response to https://github.com/gajus/youtube-player/issues/16

If you recommend that people polyfill promises themselves if needs be (with this https://github.com/stefanpenner/es6-promise most likely), then there is no need to bundle Bluebird in with youtube-player!

As @timpler has pointed out, there are considerable weight savings as well as bundle time savings to be made, see the webpack outputs before and after:

```
webpack: bundle is now INVALID.
Hash: 21194fd6ad432f1e6bc1
Version: webpack 2.0.4-beta
Time: 443ms
                Asset    Size  Chunks             Chunk Names
    youtube-player.js  307 kB       0  [emitted]  youtube-player
youtube-player.js.map  382 kB       0  [emitted]  youtube-player
chunk    {0} youtube-player.js, youtube-player.js.map (youtube-player) 286 kB [rendered]
   [39] ../dist/index.js 2.59 kB {0} [built]
   [40] ../dist/YouTubePlayer.js 2.29 kB {0} [built]
   [41] ../dist/eventNames.js 353 bytes {0} [built]
   [42] ../dist/functionNames.js 1.25 kB {0} [built]
   [43] ../dist/loadYouTubeIframeAPI.js 1.32 kB {0} [built]
     + 129 hidden modules
webpack: bundle is now VALID.
```

```
webpack: bundle is now INVALID.
Hash: a8a38f9faf3e482b6973
Version: webpack 2.0.4-beta
Time: 296ms
                Asset    Size  Chunks             Chunk Names
    youtube-player.js  115 kB       0  [emitted]  youtube-player
youtube-player.js.map  157 kB       0  [emitted]  youtube-player
chunk    {0} youtube-player.js, youtube-player.js.map (youtube-player) 99.8 kB [rendered]
   [39] ../dist/index.js 2.46 kB {0} [built]
   [40] ../dist/YouTubePlayer.js 2.29 kB {0} [built]
   [41] ../dist/eventNames.js 353 bytes {0} [built]
   [42] ../dist/functionNames.js 1.25 kB {0} [built]
   [43] ../dist/loadYouTubeIframeAPI.js 1.22 kB {0} [built]
     + 126 hidden modules
webpack: bundle is now VALID.
```
