### PR TITLE
Remove lodash to reduce library size

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "bluebird": "^3.3.0",
     "load-script": "^1.0.0",
-    "lodash": "^4.3.0",
     "sister": "^3.0.0"
   }
 }

--- a/src/YouTubePlayer.js
+++ b/src/YouTubePlayer.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import functionNames from './functionNames';
 import eventNames from './eventNames';
 
@@ -20,15 +19,14 @@ YouTubePlayer.proxyEvents = (emitter) => {
 
     events = {};
 
-    _.forEach(eventNames, (eventName) => {
-        let onEventName;
-
-        onEventName = 'on' + _.upperFirst(eventName);
-
+    let eventName, onEventName;
+    for (let i = eventNames.length; i--;) {
+        eventName = eventNames[i];
+        onEventName = 'on' + eventName.charAt(0).toUpperCase() + eventName.slice(1);
         events[onEventName] = (event) => {
             emitter.trigger(eventName, event);
         };
-    });
+    }
 
     return events;
 };
@@ -45,14 +43,16 @@ YouTubePlayer.promisifyPlayer = (playerAPIReady) => {
 
     functions = {};
 
-    _.forEach(functionNames, (functionName) => {
+    let functionName;
+    for (let i = functionNames.length; i--;) {
+        functionName = functionNames[i];
         functions[functionName] = (...args) => {
             return playerAPIReady
                 .then((player) => {
                     return player[functionName](...args);
                 });
         };
-    });
+    }
 
     return functions;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import Sister from 'sister';
 import Bluebird from 'bluebird';
 import loadYouTubeIframeAPI from './loadYouTubeIframeAPI';
@@ -39,7 +38,7 @@ export default (elementId, options = {}) => {
         throw new Error('Event handlers cannot be overwritten.');
     }
 
-    if (_.isString(elementId) && !document.getElementById(elementId)) {
+    if (typeof(elementId) === 'string' && !document.getElementById(elementId)) {
         throw new Error('Element "' + elementId + '" does not exist.');
     }
 


### PR DESCRIPTION
Lodash is a huge library. Since we only need `_.forEach` and `_.isString`, I have replaced it with plain javascript functions.