### PR TITLE
Reuse existing window.YT

### DIFF
--- a/src/loadYouTubeIframeApi.js
+++ b/src/loadYouTubeIframeApi.js
@@ -9,7 +9,7 @@ export default () => {
    * @member {Object} iframeAPIReady
    */
   const iframeAPIReady = new Promise((resolve) => {
-    if (window.YT && window.YT.Player && typeof window.YT.Player === 'function') {
+    if (window.YT && window.YT.Player && window.YT.Player instanceof Function) {
       resolve(window.YT);
 
       return;

--- a/src/loadYouTubeIframeApi.js
+++ b/src/loadYouTubeIframeApi.js
@@ -9,6 +9,12 @@ export default () => {
    * @member {Object} iframeAPIReady
    */
   const iframeAPIReady = new Promise((resolve) => {
+    if (window.YT) {
+      resolve(window.YT);
+
+      return;
+    }
+
     const previous = window.onYouTubeIframeAPIReady;
 
     // The API will call this function when page has finished downloading

--- a/src/loadYouTubeIframeApi.js
+++ b/src/loadYouTubeIframeApi.js
@@ -9,7 +9,7 @@ export default () => {
    * @member {Object} iframeAPIReady
    */
   const iframeAPIReady = new Promise((resolve) => {
-    if (window.YT) {
+    if (window.YT && window.YT.Player && typeof window.YT.Player === 'function') {
       resolve(window.YT);
 
       return;


### PR DESCRIPTION
Related to #33.

If iframe Player API code is already loaded, `window.onYouTubeIframeAPIReady` defined in `iframeAPIReady` never be called, and the returning promise never be resolved.

To prevent this, we could check whether `window.YT` is already defined and reuse it.