### PR TITLE
Add the ability to delay the resolution of async API functions until specified states are achieved (fixes #21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The downsides of using YouTube IFrame Player API are:
  * @param {Object|HTMLElement|String} elementId Either An existing YT.Player instance,
  * the DOM element or the id of the HTML element where the API will insert an <iframe>.
  * @param {YouTubePlayer~options} options See `options` (Ignored when using an existing YT.Player instance).
- * @param {boolean} strictState A flag designating whether or not to wait for
+ * @param {boolean} strictState Experimental: A flag designating whether or not to wait for
  * an acceptable state when calling supported functions. Default: `false`.
  * See `FunctionStateMap.js` for supported functions and acceptable states.
  * @returns {Object}

--- a/README.md
+++ b/README.md
@@ -38,9 +38,14 @@ The downsides of using YouTube IFrame Player API are:
  */
 
 /**
+ * @typedef YT.Player
+ * @see https://developers.google.com/youtube/iframe_api_reference
+ * */
+
+/**
  * A factory function used to produce an instance of YT.Player and queue function calls and proxy events of the resulting object.
  *
- * @param {Object|HTMLElement|String} elementId Either An existing YT.Player instance,
+ * @param {YT.Player|HTMLElement|String} elementId Either An existing YT.Player instance,
  * the DOM element or the id of the HTML element where the API will insert an <iframe>.
  * @param {YouTubePlayer~options} options See `options` (Ignored when using an existing YT.Player instance).
  * @param {boolean} strictState Experimental: A flag designating whether or not to wait for

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The downsides of using YouTube IFrame Player API are:
  * @param {YT.Player|HTMLElement|String} elementId Either An existing YT.Player instance,
  * the DOM element or the id of the HTML element where the API will insert an <iframe>.
  * @param {YouTubePlayer~options} options See `options` (Ignored when using an existing YT.Player instance).
- * @param {boolean} strictState Experimental: A flag designating whether or not to wait for
+ * @param {boolean} strictState A flag designating whether or not to wait for
  * an acceptable state when calling supported functions. Default: `false`.
  * See `FunctionStateMap.js` for supported functions and acceptable states.
  * @returns {Object}

--- a/src/FunctionStateMap.js
+++ b/src/FunctionStateMap.js
@@ -15,6 +15,10 @@ export default {
   // Accept Ended, Playing or Paused.
   seekTo: {
     acceptableStates: [0, 1, 2],
-    stateChangeRequired: true
+    stateChangeRequired: true,
+
+    // TRICKY: `seekTo` may not cause a state change if no buffering is
+    // required.
+    timeout: 3000
   }
 };

--- a/src/FunctionStateMap.js
+++ b/src/FunctionStateMap.js
@@ -1,0 +1,11 @@
+export default {
+
+  // Accept Ended or Paused.
+  pauseVideo: [0, 2],
+
+  // Accept Ended or Playing.
+  playVideo: [0, 1],
+
+  // Accept Ended, Playing or Paused.
+  seekTo: [0, 1, 2]
+};

--- a/src/FunctionStateMap.js
+++ b/src/FunctionStateMap.js
@@ -1,11 +1,20 @@
 export default {
 
   // Accept Ended or Paused.
-  pauseVideo: [0, 2],
+  pauseVideo: {
+    acceptableStates: [0, 2],
+    stateChangeRequired: false
+  },
 
   // Accept Ended or Playing.
-  playVideo: [0, 1],
+  playVideo: {
+    acceptableStates: [0, 1],
+    stateChangeRequired: false
+  },
 
   // Accept Ended, Playing or Paused.
-  seekTo: [0, 1, 2]
+  seekTo: {
+    acceptableStates: [0, 1, 2],
+    stateChangeRequired: true
+  }
 };

--- a/src/FunctionStateMap.js
+++ b/src/FunctionStateMap.js
@@ -1,20 +1,26 @@
+import PlayerStates from './constants/PlayerStates';
+
 export default {
-
-  // Accept Ended or Paused.
   pauseVideo: {
-    acceptableStates: [0, 2],
+    acceptableStates: [
+      PlayerStates.ENDED,
+      PlayerStates.PAUSED
+    ],
     stateChangeRequired: false
   },
-
-  // Accept Ended or Playing.
   playVideo: {
-    acceptableStates: [0, 1],
+    acceptableStates: [
+      PlayerStates.ENDED,
+      PlayerStates.PLAYING
+    ],
     stateChangeRequired: false
   },
-
-  // Accept Ended, Playing or Paused.
   seekTo: {
-    acceptableStates: [0, 1, 2],
+    acceptableStates: [
+      PlayerStates.ENDED,
+      PlayerStates.PLAYING,
+      PlayerStates.PAUSED
+    ],
     stateChangeRequired: true,
 
     // TRICKY: `seekTo` may not cause a state change if no buffering is

--- a/src/YouTubePlayer.js
+++ b/src/YouTubePlayer.js
@@ -48,7 +48,7 @@ YouTubePlayer.promisifyPlayer = (playerAPIReady, strictState = false) => {
         const player = await playerAPIReady;
         const playerState = player.getPlayerState();
 
-        // TRICKY: Just spread the args into the function once Babel is fixed:
+        // TODO: Just spread the args into the function once Babel is fixed:
         // https://github.com/babel/babel/issues/4270
         //
         // eslint-disable-next-line prefer-spread
@@ -101,7 +101,7 @@ YouTubePlayer.promisifyPlayer = (playerAPIReady, strictState = false) => {
       functions[functionName] = async (...args) => {
         const player = await playerAPIReady;
 
-        // TRICKY: Just spread the args into the function once Babel is fixed:
+        // TODO: Just spread the args into the function once Babel is fixed:
         // https://github.com/babel/babel/issues/4270
         //
         // eslint-disable-next-line prefer-spread

--- a/src/YouTubePlayer.js
+++ b/src/YouTubePlayer.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import functionNames from './functionNames';
 import eventNames from './eventNames';
+import FunctionStateMap from './FunctionStateMap';
 
 const YouTubePlayer = {};
 
@@ -33,21 +34,53 @@ YouTubePlayer.proxyEvents = (emitter) => {
  * @todo Proxy all of the methods using Object.keys.
  * @todo See TRICKY below.
  * @param {Promise} playerAPIReady Promise that resolves when player is ready.
+ * @param {boolean} strictState A flag designating whether or not to wait for
+ * an acceptable state when calling supported functions. Default: `false`.
  * @returns {Object}
  */
-YouTubePlayer.promisifyPlayer = (playerAPIReady) => {
+YouTubePlayer.promisifyPlayer = (playerAPIReady, strictState = false) => {
   const functions = {};
 
   _.forEach(functionNames, (functionName) => {
-    functions[functionName] = async (...args) => {
-      const player = await playerAPIReady;
+    if (strictState && FunctionStateMap[functionName] instanceof Array) {
+      functions[functionName] = async (...args) => {
+        const acceptStates = FunctionStateMap[functionName];
+        const player = await playerAPIReady;
+        const playerState = await player.getPlayerState();
 
-      // TRICKY: Just spread the args into the function once Babel is fixed:
-      // https://github.com/babel/babel/issues/4270
-      //
-      // eslint-disable-next-line prefer-spread
-      return player[functionName].apply(player, args);
-    };
+        if (acceptStates.indexOf(playerState) === -1) {
+          await new Promise((resolve) => {
+            const onPlayerStateChange = async () => {
+              const playerStateAfterChange = await player.getPlayerState();
+
+              if (acceptStates.indexOf(playerStateAfterChange) !== -1) {
+                player.removeEventListener('onStateChange', onPlayerStateChange);
+
+                resolve();
+              }
+            };
+
+            player.addEventListener('onStateChange', onPlayerStateChange);
+          });
+        }
+
+        // TRICKY: Just spread the args into the function once Babel is fixed:
+        // https://github.com/babel/babel/issues/4270
+        //
+        // eslint-disable-next-line prefer-spread
+        return player[functionName].apply(player, args);
+      };
+    } else {
+      functions[functionName] = async (...args) => {
+        const player = await playerAPIReady;
+
+        // TRICKY: Just spread the args into the function once Babel is fixed:
+        // https://github.com/babel/babel/issues/4270
+        //
+        // eslint-disable-next-line prefer-spread
+        return player[functionName].apply(player, args);
+      };
+    }
   });
 
   return functions;

--- a/src/YouTubePlayer.js
+++ b/src/YouTubePlayer.js
@@ -46,12 +46,12 @@ YouTubePlayer.promisifyPlayer = (playerAPIReady, strictState = false) => {
       functions[functionName] = async (...args) => {
         const acceptStates = FunctionStateMap[functionName];
         const player = await playerAPIReady;
-        const playerState = await player.getPlayerState();
+        const playerState = player.getPlayerState();
 
         if (acceptStates.indexOf(playerState) === -1) {
           await new Promise((resolve) => {
             const onPlayerStateChange = async () => {
-              const playerStateAfterChange = await player.getPlayerState();
+              const playerStateAfterChange = player.getPlayerState();
 
               if (acceptStates.indexOf(playerStateAfterChange) !== -1) {
                 player.removeEventListener('onStateChange', onPlayerStateChange);

--- a/src/YouTubePlayer.js
+++ b/src/YouTubePlayer.js
@@ -48,6 +48,7 @@ YouTubePlayer.promisifyPlayer = (playerAPIReady, strictState = false) => {
         const player = await playerAPIReady;
         const playerState = player.getPlayerState();
 
+        // eslint-disable-next-line no-warning-comments
         // TODO: Just spread the args into the function once Babel is fixed:
         // https://github.com/babel/babel/issues/4270
         //
@@ -101,6 +102,7 @@ YouTubePlayer.promisifyPlayer = (playerAPIReady, strictState = false) => {
       functions[functionName] = async (...args) => {
         const player = await playerAPIReady;
 
+        // eslint-disable-next-line no-warning-comments
         // TODO: Just spread the args into the function once Babel is fixed:
         // https://github.com/babel/babel/issues/4270
         //

--- a/src/YouTubePlayer.js
+++ b/src/YouTubePlayer.js
@@ -50,7 +50,7 @@ YouTubePlayer.promisifyPlayer = (playerAPIReady, strictState = false) => {
 
         if (acceptStates.indexOf(playerState) === -1) {
           await new Promise((resolve) => {
-            const onPlayerStateChange = async () => {
+            const onPlayerStateChange = () => {
               const playerStateAfterChange = player.getPlayerState();
 
               if (acceptStates.indexOf(playerStateAfterChange) !== -1) {

--- a/src/YouTubePlayer.js
+++ b/src/YouTubePlayer.js
@@ -70,12 +70,23 @@ YouTubePlayer.promisifyPlayer = (playerAPIReady, strictState = false) => {
             const onPlayerStateChange = () => {
               const playerStateAfterChange = player.getPlayerState();
 
+              let timeout;
+
+              if (typeof stateInfo.timeout === 'number') {
+                timeout = setTimeout(() => {
+                  player.removeEventListener('onStateChange', onPlayerStateChange);
+
+                  resolve();
+                }, stateInfo.timeout);
+              }
+
               if (
                 stateInfo.acceptableStates instanceof Array &&
                 stateInfo.acceptableStates.indexOf(playerStateAfterChange) !== -1
               ) {
                 player.removeEventListener('onStateChange', onPlayerStateChange);
 
+                clearTimeout(timeout);
                 resolve();
               }
             };

--- a/src/constants/PlayerStates.js
+++ b/src/constants/PlayerStates.js
@@ -1,8 +1,8 @@
 export default {
-  UNSTARTED: -1,
-  ENDED: 0,
-  PLAYING: 1,
-  PAUSED: 2,
   BUFFERING: 3,
+  ENDED: 0,
+  PAUSED: 2,
+  PLAYING: 1,
+  UNSTARTED: -1,
   VIDEO_CUED: 5
 };

--- a/src/constants/PlayerStates.js
+++ b/src/constants/PlayerStates.js
@@ -1,0 +1,8 @@
+export default {
+  UNSTARTED: -1,
+  ENDED: 0,
+  PLAYING: 1,
+  PAUSED: 2,
+  BUFFERING: 3,
+  VIDEO_CUED: 5
+};

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ let youtubeIframeAPI;
  * @param {Object|HTMLElement|String} elementId Either An existing YT.Player instance,
  * the DOM element or the id of the HTML element where the API will insert an <iframe>.
  * @param {YouTubePlayer~options} options See `options` (Ignored when using an existing YT.Player instance).
- * @param {boolean} strictState A flag designating whether or not to wait for
+ * @param {boolean} strictState Experimental: A flag designating whether or not to wait for
  * an acceptable state when calling supported functions. Default: `false`.
  * See `FunctionStateMap.js` for supported functions and acceptable states.
  * @returns {Object}

--- a/src/index.js
+++ b/src/index.js
@@ -19,9 +19,12 @@ let youtubeIframeAPI;
  *
  * @param {HTMLElement|String} elementId Either the DOM element or the id of the HTML element where the API will insert an <iframe>.
  * @param {YouTubePlayer~options} options
+ * @param {boolean} strictState A flag designating whether or not to wait for
+ * an acceptable state when calling supported functions. Default: `false`.
+ * See `FunctionStateMap.js` for supported functions and acceptable states.
  * @returns {Object}
  */
-export default (elementId, options = {}) => {
+export default (elementId, options = {}, strictState = false) => {
   const emitter = Sister();
 
   if (!youtubeIframeAPI) {
@@ -47,7 +50,7 @@ export default (elementId, options = {}) => {
     });
   });
 
-  const playerAPI = YouTubePlayer.promisifyPlayer(playerAPIReady);
+  const playerAPI = YouTubePlayer.promisifyPlayer(playerAPIReady, strictState);
 
   playerAPI.on = emitter.on;
   playerAPI.off = emitter.off;

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,18 @@ import YouTubePlayer from './YouTubePlayer';
  * @param {Object} playerVars
  * @param {Object} events
  */
+
+/**
+ * @typedef YT.Player
+ * @see https://developers.google.com/youtube/iframe_api_reference
+ * */
+
 let youtubeIframeAPI;
 
 /**
  * A factory function used to produce an instance of YT.Player and queue function calls and proxy events of the resulting object.
  *
- * @param {Object|HTMLElement|String} elementId Either An existing YT.Player instance,
+ * @param {YT.Player|HTMLElement|String} elementId Either An existing YT.Player instance,
  * the DOM element or the id of the HTML element where the API will insert an <iframe>.
  * @param {YouTubePlayer~options} options See `options` (Ignored when using an existing YT.Player instance).
  * @param {boolean} strictState Experimental: A flag designating whether or not to wait for

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ let youtubeIframeAPI;
  * @param {YT.Player|HTMLElement|String} elementId Either An existing YT.Player instance,
  * the DOM element or the id of the HTML element where the API will insert an <iframe>.
  * @param {YouTubePlayer~options} options See `options` (Ignored when using an existing YT.Player instance).
- * @param {boolean} strictState Experimental: A flag designating whether or not to wait for
+ * @param {boolean} strictState A flag designating whether or not to wait for
  * an acceptable state when calling supported functions. Default: `false`.
  * See `FunctionStateMap.js` for supported functions and acceptable states.
  * @returns {Object}


### PR DESCRIPTION
Add the ability to delay the resolution of `async` API functions until specified states are achieved. The argument is marked as experimental and should be regarded as such.