### PR TITLE
fix(src/index.js): Fix promise resolution w/ existing YT.Player

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,15 +56,17 @@ export default (elementId, options = {}, strictState = false) => {
       elementId.playVideo instanceof Function
     ) {
       player = elementId;
+
+      resolve(player);
     } else {
       const YT = await youtubeIframeAPI;
 
       player = new YT.Player(elementId, options);
-    }
 
-    emitter.on('ready', () => {
-      resolve(player);
-    });
+      emitter.on('ready', () => {
+        resolve(player);
+      });
+    }
   });
 
   const playerAPI = YouTubePlayer.promisifyPlayer(playerAPIReady, strictState);


### PR DESCRIPTION
Fix a problem where an existing YT.Player instance, that is already ready, does not allow function Promises to resolve.

Close #45