### PR TITLE
fix: always use `https` to load iframe api

### DIFF
--- a/src/loadYouTubeIframeApi.js
+++ b/src/loadYouTubeIframeApi.js
@@ -27,9 +27,8 @@ export default () => {
       resolve(window.YT);
     };
   });
-  const protocol = window.location.protocol === 'http:' ? 'http:' : 'https:';
 
-  load(protocol + '//www.youtube.com/iframe_api');
+  load('https://www.youtube.com/iframe_api');
 
   return iframeAPIReady;
 };


### PR DESCRIPTION
- Fixes `Failed to execute 'postMessage' on 'DOMWindow'` issue

Overview
--------

On our local development server, dev tools console was being spammed with error messages like:

```
www-widgetapi.js:119 Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('http://www.youtube.com') does not match the recipient window's origin ('https://www.youtube.com')
```

I traced it back to this lib, made the change in this PR, and consistently this issue has cleared up.  There is a somewhat corroborating SO question as well - http://stackoverflow.com/a/27574013/278891 .

Please let me know if there is a reason to use a protocol relative URL.  As far as I know, there aren't any compatibility issues with loading resources always via https (and only very marginal performance concerns).  This has also become the recommended way to load resources that are known to be served via https - https://www.paulirish.com/2010/the-protocol-relative-url/

cheers!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gajus/youtube-player/54)
<!-- Reviewable:end -->
