### PR TITLE
unofficial-feature/ add `volumeChange` to `eventNames`

### DIFF
--- a/src/eventNames.js
+++ b/src/eventNames.js
@@ -2,6 +2,8 @@
 
 /**
  * @see https://developers.google.com/youtube/iframe_api_reference#Events
+ * `volumeChange` is not officially supported but seems to work
+ * it emits an object: `{volume: 82.6923076923077, muted: false}`
  */
 export default [
   'ready',
@@ -9,5 +11,6 @@ export default [
   'playbackQualityChange',
   'playbackRateChange',
   'error',
-  'apiChange'
+  'apiChange',
+  'volumeChange'
 ];


### PR DESCRIPTION
Add the event `volumeChange` to the `YT.Player` events list that it is possible to subscribe to. (following #60 )

This is not officially supported by the Youtube Iframe but works in the following example.

docs: https://developers.google.com/youtube/iframe_api_reference#Events
exemple: http://jsbin.com/werasumaqo/edit?html,js,console,output
source: https://github.com/videojs/videojs-youtube/blob/master/src/Youtube.js#L235

Would need that feature to be able to continue volume implementation for a [player](https://github.com/internet4000/radio4000-player-vue) we're working on.

Was it just this or am I missing something?

Thanks a lot for your package.