### PR TITLE
trigger error when script can't be loaded

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default (maybeElementId: YouTubePlayerType | HTMLElement | string, option
   const emitter = Sister();
 
   if (!youtubeIframeAPI) {
-    youtubeIframeAPI = loadYouTubeIframeApi();
+    youtubeIframeAPI = loadYouTubeIframeApi(emitter);
   }
 
   if (options.events) {

--- a/src/loadYouTubeIframeApi.js
+++ b/src/loadYouTubeIframeApi.js
@@ -2,10 +2,11 @@
 
 import load from 'load-script';
 import type {
+  EmitterType,
   IframeApiType
 } from './types';
 
-export default (): Promise<IframeApiType> => {
+export default (emitter: EmitterType): Promise<IframeApiType> => {
   /**
    * A promise that is resolved when window.onYouTubeIframeAPIReady is called.
    * The promise is resolved with a reference to window.YT object.
@@ -32,7 +33,11 @@ export default (): Promise<IframeApiType> => {
 
   const protocol = window.location.protocol === 'http:' ? 'http:' : 'https:';
 
-  load(protocol + '//www.youtube.com/iframe_api');
+  load(protocol + '//www.youtube.com/iframe_api', (error) => {
+    if (error) {
+      emitter.trigger('error', error);
+    }
+  });
 
   return iframeAPIReady;
 };


### PR DESCRIPTION
I noticed that `youtube-player` was silently dying in cases where `youtube.com/iframe_api` was returning a `net::ERR_ABORTED`.

Considering that network errors can happen only eventually, making them very hard to catch, I find crucial that we make these errors as noisy as possible. Therefore I would suggest publishing a new minor version asap.

thank you for the great and very handy project! 💪👨‍💻