### PR TITLE
Avoid referencing undefined document

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ export default (maybeElementId: YouTubePlayerType | HTMLElement | string, option
     throw new Error('Event handlers cannot be overwritten.');
   }
 
-  if (typeof maybeElementId === 'string' && !document.getElementById(maybeElementId)) {
+  if ((typeof maybeElementId === 'string') && (typeof document !== 'undefined') && (!document.getElementById(maybeElementId))) {
     throw new Error('Element "' + maybeElementId + '" does not exist.');
   }
 


### PR DESCRIPTION
Avoid referencing `document` methods when document is not defined. This will happen when serverside rendering the player - thus causing an internal error.