### PR TITLE
Fix playing inside iframe or popup window

### DIFF
--- a/src/YouTubePlayer.js
+++ b/src/YouTubePlayer.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable promise/prefer-await-to-then */
 
 import createDebug from 'debug';
 import functionNames from './functionNames';

--- a/src/index.js
+++ b/src/index.js
@@ -53,10 +53,14 @@ export default (maybeElementId: YouTubePlayerType | HTMLElement | string, option
   options.events = YouTubePlayer.proxyEvents(emitter);
 
   const playerAPIReady = new Promise((resolve: (result: YouTubePlayerType) => void) => {
-    if (typeof maybeElementId === 'string' || maybeElementId instanceof HTMLElement) {
-      // eslint-disable-next-line promise/catch-or-return
-      youtubeIframeAPI
-        .then((YT) => {
+    if (typeof maybeElementId === 'object' && maybeElementId.playVideo instanceof Function) {
+      const player: YouTubePlayerType = maybeElementId;
+
+      resolve(player);
+    } else { // asume maybeElementId can be rendered inside
+        // eslint-disable-next-line promise/catch-or-return
+        youtubeIframeAPI
+          .then((YT) => {
           const player: YouTubePlayerType = new YT.Player(maybeElementId, options);
 
           emitter.on('ready', () => {
@@ -65,12 +69,6 @@ export default (maybeElementId: YouTubePlayerType | HTMLElement | string, option
 
           return null;
         });
-    } else if (typeof maybeElementId === 'object' && maybeElementId.playVideo instanceof Function) {
-      const player: YouTubePlayerType = maybeElementId;
-
-      resolve(player);
-    } else {
-      throw new TypeError('Unexpected state.');
     }
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ let youtubeIframeAPI;
 /**
  * A factory function used to produce an instance of YT.Player and queue function calls and proxy events of the resulting object.
  *
- * @param elementId Either An existing YT.Player instance,
+ * @param maybeElementId Either An existing YT.Player instance,
  * the DOM element or the id of the HTML element where the API will insert an <iframe>.
  * @param options See `options` (Ignored when using an existing YT.Player instance).
  * @param strictState A flag designating whether or not to wait for
@@ -57,10 +57,11 @@ export default (maybeElementId: YouTubePlayerType | HTMLElement | string, option
       const player: YouTubePlayerType = maybeElementId;
 
       resolve(player);
-    } else { // asume maybeElementId can be rendered inside
-        // eslint-disable-next-line promise/catch-or-return
-        youtubeIframeAPI
-          .then((YT) => {
+    } else {
+      // asume maybeElementId can be rendered inside
+      // eslint-disable-next-line promise/catch-or-return
+      youtubeIframeAPI
+        .then((YT) => { // eslint-disable-line promise/prefer-await-to-then
           const player: YouTubePlayerType = new YT.Player(maybeElementId, options);
 
           emitter.on('ready', () => {


### PR DESCRIPTION
When attempting to instantiate inside an iframe or popup window, the element can't be read, and the else block with ` throw new TypeError('Unexpected state.');` would be triggered.

It seems to me that it'd be a better to always attempt to play even if we can't tell if a player can be added to an element or not.  