### PR TITLE
feat: Add `otherParams` + `forceHttpsApi` options

### DIFF
--- a/examples/src/force-https/index.html
+++ b/examples/src/force-https/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src='/youtube-player.js'></script>
+</head>
+<body>
+    <div id='player-1'></div>
+
+    <script>
+    var player1,
+        firstStateChange;
+
+    player1 = YouTubePlayer('player-1', {
+        videoId: 'M7lc1UVf-VE',
+        otherParams: {
+            forceHttpsApi: true
+        }
+    });
+
+    player1
+        // Play video is a Promise.
+        // 'playVideo' is queued and will execute as soon as player is ready.
+        .playVideo()
+        .then(function () {
+            console.log('Starting to play player1. It will take some time to buffer video before it starts playing.');
+        });
+    </script>
+</body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,9 @@ type OptionsType = {|
   playerVars?: Object,
   videoId?: string,
   width?: number,
+  otherParams?: {|
+    forceHttpsApi?: boolean,
+  |},
 |};
 
 /**
@@ -39,7 +42,7 @@ export default (maybeElementId: string | HTMLElement | YouTubePlayerType, option
   const emitter = Sister();
 
   if (!youtubeIframeAPI) {
-    youtubeIframeAPI = loadYouTubeIframeApi(emitter);
+    youtubeIframeAPI = loadYouTubeIframeApi(emitter, options);
   }
 
   if (options.events) {

--- a/src/loadYouTubeIframeApi.js
+++ b/src/loadYouTubeIframeApi.js
@@ -6,7 +6,7 @@ import type {
   IframeApiType,
 } from './types';
 
-export default (emitter: EmitterType): Promise<IframeApiType> => {
+export default (emitter: EmitterType, options = undefined): Promise<IframeApiType> => {
   /**
    * A promise that is resolved when window.onYouTubeIframeAPIReady is called.
    * The promise is resolved with a reference to window.YT object.
@@ -17,7 +17,14 @@ export default (emitter: EmitterType): Promise<IframeApiType> => {
 
       return;
     } else {
-      const protocol = window.location.protocol === 'http:' ? 'http:' : 'https:';
+      let protocol;
+
+      const forceHttpsApi = options && options.otherParams && options.otherParams.forceHttpsApi;
+      if (forceHttpsApi) {
+        protocol = 'https:';
+      } else {
+        protocol = window.location.protocol === 'http:' ? 'http:' : 'https:';
+      }
 
       load(protocol + '//www.youtube.com/iframe_api', (error) => {
         if (error) {


### PR DESCRIPTION
I saw that previous attempts of this modification was closed. Since i need it for a project i do this humble PR ^^

Thanks in advance

> * Force HTTPS API Options
> 
> This option allow user to force HTTPS protocol for IframeAPI loading. With the default option, Youtube Player guess the protocol from actual `window.location``
> 
> Usage :
> ```
> player = YouTubePlayer('player', {
>     videoId: 'M7lc1UVf-VE',
>     otherParams: {
>         forceHttpsApi: true
>     }
> });